### PR TITLE
PseudoTTYPlugin: use pid_t type for ptyForkAndExec()

### DIFF
--- a/platforms/Cross/plugins/PseudoTTYPlugin/PseudoTTYPlugin.h
+++ b/platforms/Cross/plugins/PseudoTTYPlugin/PseudoTTYPlugin.h
@@ -2,7 +2,7 @@
 
 int ptyInit();
 int ptyShutdown();
-int ptyForkAndExec();
+pid_t ptyForkAndExec();
 int ptyClose();
 int ptyWindowSize();
 


### PR DESCRIPTION
See https://github.com/dtlewis290/squeakvm.org/issues/4#issue-4919012625